### PR TITLE
Adapted Methods and created About page

### DIFF
--- a/shiny_app/about_rm.R
+++ b/shiny_app/about_rm.R
@@ -1,5 +1,53 @@
 about_rm_page <- tabPanel(
     "About Responsible Metrics",
     value = "tabAboutRM",
-    h3("About Responsible Metrics")
+    h3("Contributions"),
+    br(),
+    helpText('We would like to thank all those who contributed to this proof-of-principle dashboard. We would
+             particularly like to thank Nico Riedel who designed an initial version of this dashboard, which
+             we adapted for use with multiple institutions.'),
+    br(),
+    h4("ODDPub - Open Data & Code detection"),
+    helpText('Riedel, Nico (Conceptualization, Methodology, Technical Implementation, Validation);
+                                Bobrov, Evgeny (Conceptualization, Methodology, Validation);
+                                Kip, Miriam (Conceptualization, Methodology)'),
+    br(),
+    h4("Clinical trial metrics"),
+    h5("IntoValue"),
+    helpText("Riedel, Nico (Conceptualization, Methodology, technical implementation);
+             Strech, Daniel (Conceptualization, Methodology);
+             Wieschowski, Susanne (Conceptualization, Methodology)"),
+    h5("Reporting of trial registration number"),
+    helpText("Salholz-Hillel, Maia (Conceptualization, Methodology);
+             Carlisle, Benjamin Gregory (Conceptualization, Methodology)"),
+    
+    br(),
+    h4("Robustness of animal studies"),
+    helpText('We thank Anita Bandrowski for sharing with us SciScore data from which we derived the robustness
+             metrics in animal studies displayed in this proof-of-principle dashboard'),
+    
+    
+    br(),
+    h4("Shiny app"),
+    helpText('Riedel, Nico (Conceptualization, Technical Implementation);
+                                Carlisle, Benjamin Gregory (Conceptualization, Technical Implementation);
+                                Franzen, Delwen (Conceptualization);
+                                Maia Salholz-Hillel (Conceptualization);
+                                Holst, Martin (Conceptualization);
+                                Saksone, Lana (Conceptualization);
+                                Strech, Daniel (Conceptualization);
+                                Weissgerber, Tracey (Conceptualization);
+                                Dirnagl, Ulrich (Conceptualization);
+                                Bobrov, Evgeny (Conceptualization)'),
+    
+    br(),
+    h3('Contact address'),
+    helpText('QUEST Center for Transforming Biomedical Research,'),
+    helpText('Berlin Institute of Health (BIH), Berlin, Germany'),
+    helpText('Anna-Louisa-Karsch-Str. 2'),
+    helpText('10178 Berlin '),
+    helpText('quest@bihealth.de'),
+    helpText(HTML('<a href="https://www.bihealth.org/quest-center/">
+                                      https://www.bihealth.org/quest-center/ </a>'))
 )
+

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -402,7 +402,7 @@ server <- function (input, output, session) {
                     metric_box(
                         title = "Trial Registry Number Reporting",
                         value = paste0(round(100*all_numer_trn/all_denom_trn), "%"),
-                        value_text = "of clinical trial publications reported a TRN in the abstract",
+                        value_text = "of PubMed-classified clinical trial publications reported a TRN in the abstract",
                         plot = plotlyOutput('plot_clinicaltrials_trn', height="300px"),
                         info_id = "infoTRN",
                         info_title = "Trial Registry Number Reporting",

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -164,7 +164,7 @@ server <- function (input, output, session) {
             fluidRow(
                 column(
                     8,
-                    h1(style = "margin-left:0cm", strong("Responsible Metrics Dashboard"), align = "left"),
+                    h1(style = "margin-left:0cm", strong("Proof-of-principle Responsible Metrics Dashboard"), align = "left"),
                     h4(style = "margin-left:0cm",
                        "This dashboard is a proof-of-principle overview of several metrics of open and responsible research for several German University Medical Centres (UMC's). For more detailed information on the methods used to calculate those metrics, the dataset underlying the metrics, or resources to improve your own research practices, click one of the following buttons."),
                     h4(style = "margin-left:0cm",

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -291,6 +291,22 @@ methods_page <- tabPanel(
                         estimation in most cases do not apply to early-stage exploratory research
                         (hypothesis-generating experiments). At this stage, we do not have a way of distinguishing
                                   these studies from confirmatory, hypothesis-testing experiments.")))
+    h2("Tools used for data collection"),
+    helpText(HTML('<a href="http://login.webofknowledge.com/error/Error?Src=Cookie&Alias=WOK5&Error=roaming%2Cip&PathInfo=%2F&ErrorCode=AUTH_PREFERENCE_ERROR&RouterURL=http%3A%2F%2Fwww.webofknowledge.com%2F&Domain=.webofknowledge.com"
+                  >Web of Science</a>')),
+    helpText(HTML('<a href="https://app.dimensions.ai/discover/publication">Dimensions</a>')),
+    helpText(HTML('<a href="https://numbat.bgcarlisle.com/">Numbat Systematic Review Manager</a>')),
+    helpText(HTML('<a href="https://github.com/NicoRiedel/unpaywallR"> UnpaywallR </a>')),
+    helpText(HTML('<a href="https://shareyourpaper.org/permissions/about">
+                  ShareYourPaper permissions checker API</a> from the Open Access Button')),
+    helpText(HTML('<a href="https://github.com/quest-bih/oddpub" > ODDPub </a>
+                  and <a href="https://datascience.codata.org/article/10.5334/dsj-2020-042/">
+                  related publication </a>')),
+    helpText(HTML('<a href="https://github.com/maia-sh/ctregistries"> ctregistries R package </a>')),
+    helpText(HTML('<a href="https://eu.trialstracker.net/">EU Trials Tracker </a>')),
+    helpText(HTML('Data extracted with <a href="https://www.sciscore.com/">SciScore tool</a>, also see the
+                  <a href="https://www.sciencedirect.com/science/article/pii/S2589004220308907?via%3Dihub#mmc1">
+                  related publication </a>'))
 )
 
 

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -5,7 +5,8 @@ methods_page <- tabPanel(
     h4(HTML('This dashboard displays a proof-of-principle dataset for responsible metrics at German University
     Medical Centers (UMCs). Please note that the data presented in this dashboard is still under development
     and should not be used &#8211 solely or in part &#8211 to compare UMCs or inform policy decisions.
-    You can find more information on our methods for individual metrics by extending the panels below.')),
+    You can find more information on our methods for individual metrics by extending the panels below. You
+            can also find a list of tools used for data collection at the bottom of this page.')),
     
     h2("Publication search"),
     bsCollapse(id = "methodsPanels_PublicationSearch",

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -275,22 +275,29 @@ methods_page <- tabPanel(
                              
                              HTML('In a first step, we filtered the publication dataset for animal studies based
                         on a previously published <a href=https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3104815/
-                        >PubMed search query</a>. We focused on animal studies as these The parameters in question were extracted with
+                        >PubMed search query</a>. The robustness measures were evaluated with
                         <a href="https://www.sciencedirect.com/science/article/pii/S2589004220308907">SciScore</a>,
                         an automated tool which evaluates research articles based on their adherence to rigour
                         and reproducibility criteria.'),
                              
-                             HTML("There are several limitations: We identified animal studies based on a
-                        previously published PubMed search filter which has been shown to retrieve more records
-                        than the regular search method in PubMed (<i>Limit: Animals</i>). However, we did not
-                        test its sensitivity and specificity in the context of this proof-of-principle dataset.
-                        Moreover, this PubMed search filter does not distinguish between publications in which
-                        animals are mentioned, and publications in which animals are the main research subject.
-                        It also does not identify animal studies in our publication set not indexed in PubMed.
-                        Finally, it is important to note that randomization, blinding, and sample size
-                        estimation in most cases do not apply to early-stage exploratory research
-                        (hypothesis-generating experiments). At this stage, we do not have a way of distinguishing
-                                  these studies from confirmatory, hypothesis-testing experiments.")))
+                             HTML("There are several limitations: <i>(1) Identification of animal studies.</i>
+                        We identified animal studies based on a previously published PubMed search filter
+                        which has been shown to retrieve more records than the regular search method in PubMed
+                        (<i>Limit: Animals</i>). However, we did not test its sensitivity and specificity in
+                        the context of this proof-of-principle dataset. Moreover, this PubMed search filter
+                        does not distinguish between publications in which animals are mentioned, and
+                        publications in which animals are the main research subject. It also does not identify
+                        animal studies in our publication set not indexed in PubMed. <i> (2) Evaluation of
+                        robustness measures.</i> For the purposes of this dashboard, we obtained SciScore data
+                        for publications in the PubMed Central (PMC) corpus. At this stage, we do not have this
+                        data for publications in our dataset not indexed in PMC. The robustness measures depend
+                        on the performance of the SciScore classifier (see more information on classifier
+                        performance analysis in <a href=https://www.sciencedirect.com/science/article/pii/S2589004220308907?via%3Dihub#mmc1
+                        >this publication</a>). Finally, it is important to note that randomization, blinding,
+                        and sample size estimation may not always apply, especially in early-stage
+                        exploratory research (hypothesis-generating experiments). At present, we do not have a
+                        way of distinguishing these studies from confirmatory, hypothesis-testing experiments."))),
+               
     h2("Tools used for data collection"),
     helpText(HTML('<a href="http://login.webofknowledge.com/error/Error?Src=Cookie&Alias=WOK5&Error=roaming%2Cip&PathInfo=%2F&ErrorCode=AUTH_PREFERENCE_ERROR&RouterURL=http%3A%2F%2Fwww.webofknowledge.com%2F&Domain=.webofknowledge.com"
                   >Web of Science</a>')),

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -33,8 +33,10 @@ methods_page <- tabPanel(
                                question. Based on these results, we generated a proof-of-principle dataset with
                                publications from UMCs with a specificity equal to or higher than 85 (n=13 UMCs). For
                                each UMC, we selected a random sample of 500 articles. Reviews were exluded from
-                               the development of this proof-of-principle dataset as most metrics are based on
-                                      articles.")),
+                               the development of this smaller proof-of-principle dataset as most metrics are
+                               based on articles. The code used to generate the UMC publication set, process
+                               samples for specificity checks, and create the proof-of-principle dataset are openly
+                                      available at: [enter link to repository in GitHub].")),
                                value = "methodsPanels_PublicationSearch",
                                style = "default")),
     

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -135,7 +135,7 @@ methods_page <- tabPanel(
                         a publication."),
                
                
-               methods_panel("Potential Green Open Access (OA)",
+               methods_panel("Potential Green Open Access (OA) - in progress!",
                              
                              "This metric measures how many publications currently hidden behind a paywall
                              could be made openly accessible in a repository based on journal self-archiving


### PR DESCRIPTION
- "Methods" page: added details to the methods page, including a list of tools used for data collection. TODO: still need to add tool tips for individual metrics.
- "About" page: added contributions of different sections.
- Note: both these sections are still in progress.

General note: something led to a change in how the metrics are visualised on the first page. There are now 2 metrics on each row (instead of 4). Would suggest to revert to 4 metrics per row if possible.