### PR TITLE
Added tooltips

### DIFF
--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -429,12 +429,12 @@ server <- function (input, output, session) {
                 column(
                     col_width,
                     metric_box(
-                        title = "Trial Preregistration",
+                        title = "Prospective registration",
                         value = paste0(round(100*all_numer_prereg/all_denom_prereg), "%"),
                         value_text = "of clinical trials were preregistered",
                         plot = plotlyOutput('plot_clinicaltrials_prereg', height="300px"),
                         info_id = "infoPreReg",
-                        info_title = "Trial Preregistration",
+                        info_title = "Prospective registration",
                         info_text = prereg_tooltip
                     )
                 ),
@@ -746,7 +746,7 @@ server <- function (input, output, session) {
                 column(
                     12,
                     metric_box(
-                        title = "Trial Preregistration",
+                        title = "Prospective registration",
                         value = paste0(round(100*all_numer_prereg/all_denom_prereg), "%"),
                         value_text = "of clinical trials were preregistered",
                         plot = plotlyOutput('plot_allumc_clinicaltrials_prereg', height="300px"),

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -164,9 +164,14 @@ server <- function (input, output, session) {
             fluidRow(
                 column(
                     8,
-                    h1(style = "margin-left:0cm", strong("Proof-of-principle Responsible Metrics Dashboard"), align = "left"),
+                    h1(style = "margin-left:0cm", strong("Proof-of-principle Responsible Metrics Dashboard (2018)"), align = "left"),
                     h4(style = "margin-left:0cm",
-                       "This dashboard is a proof-of-principle overview of several metrics of open and responsible research for several German University Medical Centres (UMC's). For more detailed information on the methods used to calculate those metrics, the dataset underlying the metrics, or resources to improve your own research practices, click one of the following buttons."),
+                       "This dashboard is a proof-of-principle overview of several metrics of open and robust
+                       research for several German University Medical Centres (UMCs). Besides the metrics
+                       Summary Results Reporting, Prospective Registration, and Timely Publication, all other
+                       publication-based metrics are based on publications published in 2018. For more detailed
+                       information on the methods used to calculate those metrics or the dataset underlying
+                       the metrics, click one of the following buttons."),
                     h4(style = "margin-left:0cm",
                        "This dashboard is a pilot that is still under development, and should not be used to compare UMC's or inform policy. More metrics may be added in the future."),
                     br()

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -135,7 +135,7 @@ methods_page <- tabPanel(
                         a publication."),
                
                
-               methods_panel("Potential Green Open Access (OA) - in progress!",
+               methods_panel("Potential Green Open Access (OA) - coming soon!",
                              
                              "This metric measures how many publications currently hidden behind a paywall
                              could be made openly accessible in a repository based on journal self-archiving
@@ -248,7 +248,7 @@ methods_page <- tabPanel(
                              
                              "This metric measures if the clinical trials are registered before the
                         start date of the study, according to the information given on ClinicalTrials.gov.
-                        The idea of prospective registration of studies is to make the trail specifications,
+                        The idea of prospective registration of studies is to make the trial specifications,
                         including primary and secondary outcomes, publicly available before study start.
                         Prospective registration adds transparency, helps protect against outcome switching.",
                              

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -3,10 +3,10 @@ methods_page <- tabPanel(
     h1("Methods"),
     
     h4(HTML('This dashboard displays a proof-of-principle dataset for responsible metrics at German University
-    Medical Centers (UMCs). Please note that the data presented in this dashboard is still under development
-    and should not be used &#8211 solely or in part &#8211 to compare UMCs or inform policy decisions.
+    Medical Centers (UMCs) for 2018. Please note that the data presented in this dashboard is still under
+    development and should not be used &#8211 solely or in part &#8211 to compare UMCs or inform policy decisions.
     You can find more information on our methods for individual metrics by extending the panels below. You
-            can also find a list of tools used for data collection at the bottom of this page.')),
+    can also find a list of tools used for data collection at the bottom of this page.')),
     
     h2("Publication search"),
     bsCollapse(id = "methodsPanels_PublicationSearch",

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -322,28 +322,108 @@ methods_page <- tabPanel(
 
 ## Tooltips for Open Science metrics
 
-openaccess_tooltip <- strwrap("This metric ...")
+openaccess_tooltip <- strwrap("The Open Access metric shows the percentage of research publications that are
+                             published as Open Access (OA) articles. Gold OA denotes publication in a pure
+                             OA journal. Green OA denotes a freely available repository version. Hybrid OA
+                             denotes an OA publication in a journal with offers both a subscription based
+                             model as well as an Open Access option. For some articles no Open Access
+                             information was available.") %>%
 
-opendata_tooltip <- strwrap("This metric ...")
+paste(collapse = " ")
 
-opencode_tooltip <- strwrap("This metric ...")
+opendata_tooltip <- strwrap("The Open Data metric measures the percentage of publications in English and for
+                            which the full text could be screened that state that they shared their research data.
+                            Openly shared data makes research more transparent, as research findings can be
+                            reproduced. Additionally, shared datasets can be reused and combined by other
+                            scientists to answer new research questions.") %>%
+
+paste(collapse = " ")
+
+opencode_tooltip <- strwrap("The Open Code metric measures the percentage of publications in English and for
+                            which the full text could be screened that state that they shared their analysis code.
+                            Like openly shared data, Open Code makes research more transparent, as research
+                            findings can be reproduced.") %>%
+
+paste(collapse = " ")
 
 ## Tooltips for Clinical Trials metrics
 
-trn_tooltip <- strwrap("This metric ...")
+trn_tooltip <- strwrap("This metric measures how many publications classified by PubMed as clinical trial
+                        publications report a trial registration number (TRN) in the abstract and in the
+                        secondary identifier metadata of the publication. Reporting of clinical trial registration
+                        numbers in related publications facilitates transparent linkage between registration and
+                        publication. The CONSORT as well as the ICMJE Recommendations for the Conduct, Reporting,
+                        Editing, and Publication of Scholarly Work in Medical Journals call for reporting
+                        <i>&#39trial registration number and name of the trial register&#39</i> in both the
+                       full-text and abstract.") %>%
 
-sumres_tooltip <- strwrap("This metric ...")
+paste(collapse = " ")
 
-prereg_tooltip <- strwrap("This metric ...")
+sumres_tooltip <- strwrap("This metric measures how many clinical trials registered in the
+                        EU Clinical Trials Register that are due to report their results have already
+                        done so. A trial is due to report its results 12 month after trial completion.
+                        The data were retrieved from the EU Trials Tracker by the EBM DataLab
+                        (eu.trialstracker.net). Clinical trials are expensive and have often many contributing
+                        patients. A fast dissemination of the trial results is crucial to make the evidence
+                        gained in those trials available. The World Health organization recommends publishing
+                        clinical trial results within one year after the end of a study.") %>%
+    
+paste(collapse = " ")
 
-timpub_tooltip <- strwrap("This metric ...")
+prereg_tooltip <- strwrap("This metric measures if the clinical trials are registered before the
+                        start date of the study, according to the information given on ClinicalTrials.gov.
+                        The idea of prospective registration of studies is to make the trial specifications,
+                        including primary and secondary outcomes, publicly available before study start.
+                        Prospective registration adds transparency, helps protect against outcome switching.") %>%
+    
+paste(collapse = " ")
+
+timpub_tooltip <- strwrap("This metric measures how many clinical trials registered on ClinicalTrials.gov
+                        reported their results either as a journal publication or as summary results on the
+                        trials registry within 2 or 5 years after completion. Trials completed between 2009
+                        and 2013 were considered. The results were previously published as part of the
+                        IntoValue study (https://s-quest.bihealth.org/intovalue/). Clinical trials are expensive
+                        and often have many contributing patients. A fast dissemination of the trial results
+                        is crucial to make the evidence gained in those trials available. The World Health
+                        organization recommends publishing clinical trial results within one year after the
+                        end of a study.") %>%
+
+paste(collapse = " ")
 
 ## Tooltips for Robustness metrics
 
-randomization_tooltip <- strwrap("This metric shows ...")
+randomization_tooltip <- strwrap("This metric measures how many animal studies report a statement on
+                            randomization of subjects into groups. Animal studies were identified using a
+                            previously published PubMed search filter. Reporting of randomization was evaluated
+                            with SciScore, an automated tool which evaluates research articles based on their
+                            adherence to rigour and reproducibility criteria. Only publications in the
+                            PubMed Central corpus and which could be analyzed by SciScore are were included
+                            in this analysis.") %>%
+    
+paste(collapse = " ")
 
-blinding_tooltip <- strwrap("This other metric shows ...")
 
-power_tooltip <- strwrap("This other metric shows ...")
+blinding_tooltip <- strwrap("This metric measures how many animal studies report a statement on whether
+                            investigators were blinded to group assignment and/or outcome assessment. Animal
+                            studies were identified using a previously published PubMed search filter. Reporting
+                            of blinding was evaluated with SciScore, an automated tool which evaluates research
+                            articles based on their adherence to rigour and reproducibility criteria. Only
+                            publications in the PubMed Central corpus and which could be analyzed by SciScore
+                            are were included in this analysis.") %>%
 
-iacuc_tooltip <- strwrap("This other metric shows ...")
+paste(collapse = " ")
+
+
+power_tooltip <- strwrap("This metric measures how many animal studies report a statement on sample size
+                         calculation. Animal studies were identified using a previously published PubMed search
+                         filter. Reporting of sample size calculation was evaluated with SciScore, an automated
+                         tool which evaluates research articles based on their adherence to rigour and
+                         reproducibility criteria. Only publications in the PubMed Central corpus and which
+                         could be analyzed by SciScore are were included in this analysis.") %>%
+    
+paste(collapse = " ")
+
+# iacuc_tooltip <- strwrap("This metric measures how many animal studies report an Institutional animal care and
+#                          use committee statement.") %>%
+#     
+# paste(collapse = " ")

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -272,9 +272,8 @@ methods_page <- tabPanel(
                              HTML("The robustness metrics assess whether animal studies in our publication set
                         adhere to a core set of reporting standards for animal studies as described by
                         <a href=https://www.nature.com/articles/nature11556>Landis et al. (2012)</a>.
-                        Specifically, we focus on the following research parameters: reporting of blinding,
-                        randomization, and sample size estimation. We also display whether an Institutional
-                                  Animal Care and Use Committee (IACUC) statement is reported."),
+                        Specifically, we focus on the following research parameters: reporting of investigator
+                        blinding, randomization of subjects, and sample size estimation."),
                              
                              HTML('In a first step, we filtered the publication dataset for animal studies based
                         on a previously published <a href=https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3104815/


### PR DESCRIPTION
- Added tooltips for all metrics except for IACUC (commented out)
- Added mention of 2018 in the title and main description
- Changed trial preregistration to prospective registration
- Minor changes to the methods section

TODO: remove the IACUC plots until we decide whether this can be included.