### PR TITLE
Final changes of first version to pitch

### DIFF
--- a/shiny_app/about_rm.R
+++ b/shiny_app/about_rm.R
@@ -1,37 +1,46 @@
 about_rm_page <- tabPanel(
     "About Responsible Metrics",
     value = "tabAboutRM",
-    h3("Contributions"),
+    h2("Contributions"),
     br(),
     helpText('We would like to thank all those who contributed to this proof-of-principle dashboard. We would
              particularly like to thank Nico Riedel who created the original version of this dashboard, which
-             we adapted for use with multiple institutions.'),
+             we adapted for use with clinical trials and multiple institutions.'),
+    # br(),
+    # h4("UMC publication search"),
+    # helpText('Franzen, Delwen (Conceptualization, Methodology, Technical Implementation, Validation); Saksone, Lana (Conceptualization, Methodology, Validation); Grabitz, Peter (Conceptualization, Methodology); Riedel, Nico (Conceptualization, Methodology, Technical Implementation); Carlisle, Benjamin Gregory (Methodology, Technical Implementation, Validation), Holst, Martin (Conceptualization, Validation); Salholz-Hillel, Maia (Conceptualization, Methodology); Strech, Daniel (Conceptualization, Methodology)'),
+    # br(),
+    # h4("ODDPub - Open Data & Code detection"),
+    # helpText('Riedel, Nico (Conceptualization, Methodology, Technical Implementation, Validation);
+    #                             Bobrov, Evgeny (Conceptualization, Methodology, Validation);
+    #                             Kip, Miriam (Conceptualization, Methodology)'),
     br(),
-    h4("UMC publication search"),
-    helpText('Franzen, Delwen (Conceptualization, Methodology, Technical Implementation, Validation); Saksone, Lana (Conceptualization, Methodology, Validation); Grabitz, Peter (Conceptualization, Methodology); Riedel, Nico (Conceptualization, Methodology, Technical Implementation); Carlisle, Benjamin Gregory (Methodology, Technical Implementation, Validation), Holst, Martin (Conceptualization, Validation); Salholz-Hillel, Maia (Conceptualization, Methodology); Strech, Daniel (Conceptualization, Methodology)'),
-    br(),
-    h4("ODDPub - Open Data & Code detection"),
-    helpText('Riedel, Nico (Conceptualization, Methodology, Technical Implementation, Validation);
-                                Bobrov, Evgeny (Conceptualization, Methodology, Validation);
-                                Kip, Miriam (Conceptualization, Methodology)'),
-    br(),
-    h4("Clinical trial metrics"),
-    h5("IntoValue"),
-    helpText("Riedel, Nico (Conceptualization, Methodology, technical implementation);
+    h3("Metrics"),
+    h4("Prospective registration, Reporting within 2 years, Reporting within 5 years"),
+    helpText("Riedel, Nico (Conceptualization, Methodology, Technical Implementation);
              Strech, Daniel (Conceptualization, Methodology);
-             Wieschowski, Susanne (Conceptualization, Methodology)"),
-    h5("Reporting of trial registration number"),
+             Wieschowski, Susanne (Conceptualization, Methodology);
+             Salholz-Hillel, Maia (Validation);
+             Carlisle, Benjamin Gregory (Technical Implementation)"),
+    h4("Reporting of trial registration number in publications"),
     helpText("Salholz-Hillel, Maia (Conceptualization, Methodology);
              Carlisle, Benjamin Gregory (Conceptualization, Methodology)"),
+    h4("Summary results reporting in EUCTR"),
+    helpText("EU TrialsTracker;
+             Carlisle, Benjamin Gregory (Technical Implementation);
+             Delwen Franzen (Technical Implementation)"),
+    h4("Open Access"),
+    helpText("Delwen Franzen (Conceptualization, Methodology, Technical Implementation);
+             Nico Riedel (Conceptualization, Methodology, Technical Implementation)"),
+    
+    # br(),
+    # h4("Robustness of animal studies"),
+    # helpText('We thank Anita Bandrowski for sharing with us SciScore data from which we derived the robustness
+    #          metrics in animal studies displayed in this proof-of-principle dashboard'),
+    
     
     br(),
-    h4("Robustness of animal studies"),
-    helpText('We thank Anita Bandrowski for sharing with us SciScore data from which we derived the robustness
-             metrics in animal studies displayed in this proof-of-principle dashboard'),
-    
-    
-    br(),
-    h4("Shiny app"),
+    h3("Shiny app"),
     helpText('Riedel, Nico (Conceptualization, Technical Implementation);
                                 Carlisle, Benjamin Gregory (Conceptualization, Technical Implementation);
                                 Franzen, Delwen (Conceptualization, Technical Implementation);
@@ -46,7 +55,7 @@ about_rm_page <- tabPanel(
                                 Bobrov, Evgeny (Conceptualization)'),
     
     br(),
-    h3('Contact address'),
+    h2('Contact address'),
     helpText('QUEST Center for Transforming Biomedical Research,'),
     helpText('Berlin Institute of Health (BIH), Berlin, Germany'),
     helpText('Anna-Louisa-Karsch-Str. 2'),

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -459,7 +459,7 @@ server <- function (input, output, session) {
             preregvaltext <- "No clinical trials for this metric were captured by this method for this UMC"
         } else {
             preregval <- paste0(round(100*all_numer_prereg/all_denom_prereg), "%")
-            preregvaltext <- "of registered clinical trials were prospectively registered"
+            preregvaltext <- "of clinical trials were prospectively registered in ClinicalTrials.gov or DRKS"
         }
 
         ## Value for timely pub 2a
@@ -1282,7 +1282,7 @@ server <- function (input, output, session) {
                     metric_box(
                         title = "Prospective registration",
                         value = paste0(round(100*all_numer_prereg/all_denom_prereg), "%"),
-                        value_text = "of registered clinical trials were prospectively registered",
+                        value_text = "of clinical trials were prospectively registered in ClinicalTrials.gov or DRKS",
                         plot = plotlyOutput('plot_allumc_clinicaltrials_prereg', height="300px"),
                         info_id = "infoALLUMCPreReg",
                         info_title = "Prospective registration (All UMCs)",

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -634,7 +634,7 @@ server <- function (input, output, session) {
             sumresvaltext <- "No clinical trials for this metric were captured by this method for this UMC"
         } else {
             sumresval <- paste0(sumres_percent, "%")
-            sumresvaltext <- "of due clinical trials report summary results"
+            sumresvaltext <- "of due clinical trials registered in EUCTR reported summary results"
         }
 
         ## Value for prereg
@@ -736,7 +736,7 @@ server <- function (input, output, session) {
             sumresvaltext <- "No clinical trials for this metric were captured by this method for this UMC"
         } else {
             sumresval <- paste0(sumres_percent, "%")
-            sumresvaltext <- "of due clinical trials report summary results"
+            sumresvaltext <- "of due clinical trials registered in EUCTR reported summary results"
         }
 
 
@@ -747,15 +747,15 @@ server <- function (input, output, session) {
                 column(
                     col_width,
                     metric_box(
-                        title = "Summary Results Reporting",
+                        title = "Summary Results Reporting in EUCTR",
                         value = sumresval,
                         value_text = sumresvaltext,
                         plot = plotlyOutput('plot_clinicaltrials_sumres', height="300px"),
                         info_id = "infoSumRes",
-                        info_title = "Summary Results Reporting",
+                        info_title = "Summary Results Reporting in EUCTR",
                         info_text = sumres_tooltip,
                         lim_id = "limSumRes",
-                        lim_title = "Limitations: Summary Results Reporting",
+                        lim_title = "Limitations: Summary Results Reporting in EUCTR",
                         lim_text = lim_sumres_tooltip
                     )
                 ),
@@ -1263,15 +1263,15 @@ server <- function (input, output, session) {
                 column(
                     12,
                     metric_box(
-                        title = "Summary Results Reporting",
+                        title = "Summary Results Reporting in EUCTR",
                         value = paste0(round(100*all_numer_sumres/all_denom_sumres), "%"),
-                        value_text = "of due clinical trials report summary results",
+                        value_text = "of due clinical trials registered in EUCTR reported summary results",
                         plot = plotlyOutput('plot_allumc_clinicaltrials_sumres', height="300px"),
                         info_id = "infoALLUMCSumRes",
-                        info_title = "Summary results reporting (All UMCs)",
+                        info_title = "Summary results reporting in EUCTR (All UMCs)",
                         info_text = allumc_clinicaltrials_sumres_tooltip,
                         lim_id = "limALLUMCSumRes",
-                        lim_title = "Limitations: Summary results reporting (All UMCs)",
+                        lim_title = "Limitations: Summary results reporting in EUCTR (All UMCs)",
                         lim_text = lim_allumc_clinicaltrials_sumres_tooltip
                     )
                 )

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -151,21 +151,19 @@ server <- function (input, output, session) {
                     8,
                     h1(style = "margin-left:0cm", strong("Dashboard for open science in clinical research"), align = "left"),
                     h4(style = "margin-left:0cm",
-                       "This proof-of-principle dashboard provides an overview of several metrics of open and robust
-                       research for several German University Medical Centres (UMCs). This dashboard is a pilot
-                       that is still under development, and should not be used to compare UMCs or inform policy.
-                       More metrics may be added in the future."),
+                       "This is a proof-of-principle dashboard for Open Science in clinical research at University
+                       Medical Centers (UMCs) in Germany. This dashboard is a pilot that is still under development,
+                       and should not be used to compare UMCs or inform policy. More metrics may be added in the future."),
                     h4(style = "margin-left:0cm",
-                       "The dashboard includes data of UMCs for which publications could be identified with a
-                       precision equal to or higher than 85%. The data displayed is based on a random sample of
-                       500 articles per UMC. An example UMC is highlighted. Besides the metrics
-                       Summary Results Reporting, Prospective Registration, and Timely Publication, all other
-                       metrics are based on publications from 2018. For the Open Science and Robustness metrics,
-                       the data can be viewed as 1) the percentage of analyzable publications which display the
-                       given metric; 2) the absolute number of eligible publications which display the given
-                       metric. For each metric, you can find an overview of the methods and limitations by clicking
-                       on the relevant symbols. For more detailed information on the methods and underlying datasets
-                       used to calculate those metrics, visit the Methods or Datasets pages."),
+                       "The dashboard includes data relating to clinical trials of UMCs in Germany. While the dashboard
+                       displays the average across all UMCs, you can also view the data for a given UMC by selecting
+                       it in the drop-down menu. Once selected, you will see this UMC's data contextualized to the average
+                       of all included UMCs. For the Open Access metrics, the data can be viewed as either 1) the percentage
+                       of analyzable publications which display the given metric; or 2) the absolute number of eligible
+                       publications which display the given metric (click on the toggle to visualise both options). For
+                       each metric, you can find an overview of the methods and limitations by clicking on the relevant
+                       symbols. For more detailed information on the methods and underlying datasets used to calculate
+                       those metrics, visit the Methods or Datasets pages."),
                     br()
                 ),
                 column(

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -534,15 +534,15 @@ server <- function (input, output, session) {
                 column(
                     col_width,
                     metric_box(
-                        title = "Trial Registry Number Reporting",
+                        title = "Reporting of Trial Registration Number in publications",
                         value = paste0(round(100*all_numer_trn/all_denom_trn), "%"),
-                        value_text = "of clinical trials reported a registry number in the abstract",
+                        value_text = "of clinical trials reported a trial registration number in the abstract",
                         plot = plotlyOutput('plot_clinicaltrials_trn', height="300px"),
                         info_id = "infoTRN",
-                        info_title = "Trial Registry Number Reporting",
+                        info_title = "Reporting of Trial Registration Number in publications",
                         info_text = trn_tooltip,
                         lim_id = "limTRN",
-                        lim_title = "Limitations: Trial Registry Number Reporting",
+                        lim_title = "Limitations: Reporting of Trial Registration Number in publications",
                         lim_text = lim_trn_tooltip
                     )
                 )
@@ -1246,9 +1246,9 @@ server <- function (input, output, session) {
                 column(
                     12,
                     metric_box(
-                        title = "TRN Reporting",
+                        title = "Reporting a Trial Registration Number in publications",
                         value = paste0(round(100*all_numer_trn/all_denom_trn), "%"),
-                        value_text = "of clinical trials reported a TRN in the abstract",
+                        value_text = "of clinical trials reported a trial registration number in the abstract",
                         plot = plotlyOutput('plot_allumc_clinicaltrials_trn', height="300px"),
                         info_id = "infoALLUMCTRN",
                         info_title = "TRN reporting (All UMCs)",

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -1009,7 +1009,7 @@ server <- function (input, output, session) {
         
         wellPanel(
             style="padding-top: 0px; padding-bottom: 0px;",
-            h2(strong("Open Science"), align = "left"),
+            h2(strong("Open Access"), align = "left"),
             checkboxInput(
                 "opensci_absnum",
                 strong("Show absolute numbers"),
@@ -1133,7 +1133,7 @@ server <- function (input, output, session) {
 
         wellPanel(
             style="padding-top: 0px; padding-bottom: 0px;",
-            h2(strong("Open Science"), align = "left"),
+            h2(strong("Open Access"), align = "left"),
             fluidRow(
                 column(
                     12,

--- a/shiny_app/app.R
+++ b/shiny_app/app.R
@@ -1021,7 +1021,7 @@ server <- function (input, output, session) {
                     metric_box(
                         title = "Open Access (OA)",
                         value = paste0(round(100*all_numer_oa/all_denom_oa), "%"),
-                        value_text = "of 2018 publications are Open Access",
+                        value_text = "of publications are Open Access",
                         plot = plotlyOutput('plot_opensci_oa', height="300px"),
                         info_id = "infoOpenAccess",
                         info_title = "Open Access",
@@ -1140,7 +1140,7 @@ server <- function (input, output, session) {
                     metric_box(
                         title = "Open Access",
                         value = paste0(round(100*all_numer_oa/all_denom_oa), "%"),
-                        value_text = "of 2018 publications are Open Access",
+                        value_text = "of publications are Open Access",
                         plot = plotlyOutput('plot_allumc_openaccess', height="300px"),
                         info_id = "infoALLUMCOpenAccess",
                         info_title = "Open Access (All UMCs)",

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -298,22 +298,22 @@ methods_page <- tabPanel(
     ##                     exploratory research (hypothesis-generating experiments). At present, we do not have a
     ##                     way of distinguishing these studies from confirmatory, hypothesis-testing experiments."))),
                
-    h2("Tools used for data collection"),
-    helpText(HTML('<a href="http://login.webofknowledge.com/error/Error?Src=Cookie&Alias=WOK5&Error=roaming%2Cip&PathInfo=%2F&ErrorCode=AUTH_PREFERENCE_ERROR&RouterURL=http%3A%2F%2Fwww.webofknowledge.com%2F&Domain=.webofknowledge.com"
-                  >Web of Science</a>')),
-    helpText(HTML('<a href="https://app.dimensions.ai/discover/publication">Dimensions</a>')),
-    helpText(HTML('<a href="https://numbat.bgcarlisle.com/">Numbat Systematic Review Manager</a>')),
+    h3("Tools used for data collection"),
+    #helpText(HTML('<a href="http://login.webofknowledge.com/error/Error?Src=Cookie&Alias=WOK5&Error=roaming%2Cip&PathInfo=%2F&ErrorCode=AUTH_PREFERENCE_ERROR&RouterURL=http%3A%2F%2Fwww.webofknowledge.com%2F&Domain=.webofknowledge.com"
+    #              >Web of Science</a>')),
+    #helpText(HTML('<a href="https://app.dimensions.ai/discover/publication">Dimensions</a>')),
+    #helpText(HTML('<a href="https://numbat.bgcarlisle.com/">Numbat Systematic Review Manager</a>')),
     helpText(HTML('<a href="https://github.com/NicoRiedel/unpaywallR"> UnpaywallR </a>')),
     helpText(HTML('<a href="https://shareyourpaper.org/permissions/about">
                   ShareYourPaper permissions checker API</a> from the Open Access Button')),
-    helpText(HTML('<a href="https://github.com/quest-bih/oddpub" > ODDPub </a>
-                  and <a href="https://datascience.codata.org/article/10.5334/dsj-2020-042/">
-                  related publication </a>')),
+    #helpText(HTML('<a href="https://github.com/quest-bih/oddpub" > ODDPub </a>
+    #              and <a href="https://datascience.codata.org/article/10.5334/dsj-2020-042/">
+    #              related publication </a>')),
     helpText(HTML('<a href="https://github.com/maia-sh/ctregistries"> ctregistries R package </a>')),
-    helpText(HTML('<a href="https://eu.trialstracker.net/">EU Trials Tracker </a>')),
-    helpText(HTML('Data extracted with <a href="https://www.sciscore.com/">SciScore tool</a>, also see the
-                  <a href="https://www.sciencedirect.com/science/article/pii/S2589004220308907?via%3Dihub#mmc1">
-                  related publication </a>'))
+    helpText(HTML('<a href="https://eu.trialstracker.net/">EU Trials Tracker </a>'))
+    #helpText(HTML('Data extracted with <a href="https://www.sciscore.com/">SciScore tool</a>, also see the
+    #              <a href="https://www.sciencedirect.com/science/article/pii/S2589004220308907?via%3Dihub#mmc1">
+    #              related publication </a>'))
 )
 
 

--- a/shiny_app/methods_page.R
+++ b/shiny_app/methods_page.R
@@ -2,47 +2,144 @@ methods_page <- tabPanel(
     "Methods", value = "tabMethods",
     h1("Methods"),
     
-    h4(HTML('This dashboard displays a proof-of-principle dataset for responsible metrics at German University
-    Medical Centers (UMCs) for 2018. Please note that the data presented in this dashboard is still under
+    h4(HTML('This is a proof-of-principle dashboard for Open Science in clinical research at German University
+    Medical Centers (UMCs). Please note that the data presented in this dashboard is still under
     development and should not be used &#8211 solely or in part &#8211 to compare UMCs or inform policy decisions.
     You can find more information on our methods for individual metrics by extending the panels below. You
     can also find a list of tools used for data collection at the bottom of this page.')),
     
-    h2("Publication search"),
-    bsCollapse(id = "methodsPanels_PublicationSearch",
-               bsCollapsePanel(strong("Publication Search"),
-                               p(HTML("Many of the assessed metrics are publication-based metrics. To assess those
-                               metrics on the institutional level, we first had to identify publications
-                               that can be assigned to one of the UMCs in Germany. We searched
-                               Web of Science for publications published in 2018 with at least one author
-                               at each UMC. We used the organisation-enhanced index of the Web of Science
-                               Core Collection to disambiguate author affiliations. As a proxy for the publication
-                               output of UMCs, we identified biomedical publications at the aforementioned
-                               institutions using a combination of biomedical journal-level subject categories
-                               in Web of Science and article-level categories in Dimensions. The results were
-                               filtered for the following document types: &#39Article&#39 and &#39Review&#39.
-                               We included publications in all languages. Web of Science searches and extractions
-                               were performed between 14/08/2020 and 22/09/2020. The Dimensions query was
-                               performed on 22/09/2020.
-                               <br>
-                               <br>To evaluate the precision of our approach, we performed a manual check of
-                               a sample of publications per UMC. A
-                               <a href=https://osf.io/a248e/>detailed protocol</a> of our precision checks
-                               is openly available in OSF. Briefly, 50 publications per UMC were manually checked
-                               as to whether any author is affiliated to the medical faculty of the university of
-                               question. Based on these results, we generated a proof-of-principle dataset with
-                               publications from UMCs with a precision equal to or greater than 85% (n=13 UMCs). For
-                               each UMC, we selected a random sample of 500 articles. Reviews were exluded from
-                               this proof-of-principle dataset as most metrics are
-                               based on articles. This dashboard displays the data of one of these UMCs and
-                               contextualizes it to the data of all UMCs included in the proof-of-principle dataset.")),
-                               value = "methodsPanels_PublicationSearch",
+    # h2("Publication search"),
+    # bsCollapse(id = "methodsPanels_PublicationSearch",
+    #            bsCollapsePanel(strong("Publication Search"),
+    #                            p(HTML("Many of the assessed metrics are publication-based metrics. To assess those
+    #                            metrics on the institutional level, we first had to identify publications
+    #                            that can be assigned to one of the UMCs in Germany. We searched
+    #                            Web of Science for publications published in 2018 with at least one author
+    #                            at each UMC. We used the organisation-enhanced index of the Web of Science
+    #                            Core Collection to disambiguate author affiliations. As a proxy for the publication
+    #                            output of UMCs, we identified biomedical publications at the aforementioned
+    #                            institutions using a combination of biomedical journal-level subject categories
+    #                            in Web of Science and article-level categories in Dimensions. The results were
+    #                            filtered for the following document types: &#39Article&#39 and &#39Review&#39.
+    #                            We included publications in all languages. Web of Science searches and extractions
+    #                            were performed between 14/08/2020 and 22/09/2020. The Dimensions query was
+    #                            performed on 22/09/2020.
+    #                            <br>
+    #                            <br>To evaluate the precision of our approach, we performed a manual check of
+    #                            a sample of publications per UMC. A
+    #                            <a href=https://osf.io/a248e/>detailed protocol</a> of our precision checks
+    #                            is openly available in OSF. Briefly, 50 publications per UMC were manually checked
+    #                            as to whether any author is affiliated to the medical faculty of the university of
+    #                            question. Based on these results, we generated a proof-of-principle dataset with
+    #                            publications from UMCs with a precision equal to or greater than 85% (n=13 UMCs). For
+    #                            each UMC, we selected a random sample of 500 articles. Reviews were exluded from
+    #                            this proof-of-principle dataset as most metrics are
+    #                            based on articles. This dashboard displays the data of one of these UMCs and
+    #                            contextualizes it to the data of all UMCs included in the proof-of-principle dataset.")),
+    #                            value = "methodsPanels_PublicationSearch",
+    #                            style = "default")),
+    
+    h3("Identification of clinical trials"),
+    bsCollapse(id = "methodsPanels_IdentificationTrials",
+               bsCollapsePanel(strong("Identification of clinical trials"),
+                               p(HTML("IntoValue study.")),
+                               value = "methodsPanels_IdentificationTrials",
                                style = "default")),
     
-    
-    h2("Open Science"),
-    bsCollapse(id = "methodsPanels_OpenScience",
+    h3("Trial Registration"),
+    bsCollapse(id = "methodsPanels_TrialRegistration",
+               methods_panel("Prospective registration",
+                             
+                             "This metric measures if the clinical trials are registered before the
+                        start date of the study, according to the information given on ClinicalTrials.gov and DRKS.
+                        The idea of prospective registration of studies is to make the trial specifications,
+                        including primary and secondary outcomes, publicly available before study start.
+                        Prospective registration adds transparency, helps protect against outcome switching.",
+                             
+                             "We used the same methods as for the timely reporting metric to identify trials
+                             from UMCs. To assess if a study has been prospectively registered, we compare
+                        the date the study was first submitted to the registry with the
+                        start date given in the registry. As some of the earlier dates in the database
+                        only stated the month but not the exact day and to account for other possible delays
+                        we chose a conservative estimate of prospective registration and allow for a delay
+                        between start and registration date of up to 60 days.",
+                             
+                             "Like in the case of the summary results metric, we only focused on the
+                        ClinicalTrials.gov and DRKS while there are other available registries as well.
+                        Also, we rely on the information on ClinicalTrials.gov and DRKS being accurate."),
                
+               methods_panel("Reporting of Trial Registration Number (TRN)",
+                             
+                             HTML("Reporting of clinical trial registration numbers in related publications
+                             facilitates transparent linkage between registration and publication and enhances
+                             the value of the individual parts towards more responsible biomedical research
+                             and evidence-based medicine. The <a 
+                             href=https://www.sciencedirect.com/science/article/pii/S0140673607618352?via%3Dihub>
+                             Consolidated Standards of Reporting Trials (CONSORT)</a>
+                             as well as the <a href=http://www.icmje.org/recommendations/>ICMJE Recommendations
+                             for the Conduct, Reporting, Editing, and Publication of Scholarly Work in Medical
+                             Journals</a> call for reporting <i>&#39trial registration number and name of the
+                             trial register&#39</i> in both the full-text and abstract."),
+                             
+                             HTML('We developed an <a href="https://github.com/maia-sh/ctregistries">open source R
+                                  package</a> for the detection and classification of clinical trial registration
+                                  numbers. Our regular-expression-based algorithm searches text strings for
+                                  matches to TRN patterns for all PubMed-indexed and ICTRP-network registries.
+                                  In a first step, we filtered the publication dataset for PubMed-classified
+                                  human clinical trials. Then, we used the aforementioned package to detect
+                                  and classify trial registration numbers in the PubMed secondary identifier
+                                  metadata and abstract.'),
+                             
+                             HTML("Our algorithm does not distinguish true TRNs that do not resolve to a registration.
+                             Moreover, the algorithm does not determine whether the TRN is reported as a registration
+                                  for the publication&#39s study (i.e., clinical trial result) or is otherwise
+                                  mentioned (i.e., in a review, reference to other clinical trials, etc.)"))),
+    h3("Trial Reporting"),
+    bsCollapse(id = "methodsPanels_TrialReporting",
+               methods_panel("Summary results reporting in EUCTR",
+                             
+                             "This metric measures how many clinical trials registered in the
+                        EU Clinical Trials Register (EUCTR) that are due to report their results have already
+                        done so. A trial is due to report its results 12 month after trial completion.
+                        Clinical trials are expensive and have often many contributing patients.
+                        A fast dissemination of the trial results is crucial to make the evidence gained
+                        in those trials available. The World Health organization recommends publishing
+                        clinical trial results within one year after the end of a study.",
+                             
+                             HTML('The data were retrieved for all UMCs included in this proof-of-principle
+                             dataset from the
+                        <a href="https://eu.trialstracker.net">EU Trials Tracker</a> by the EBM DataLab.'),
+                             
+                             "The EU Trials Tracker does not measure for how long the trials have been due."),
+               
+               methods_panel("Results reporting (2-year and 5-year reporting)",
+                             
+                             "This metric measures how many clinical trials registered in ClinicalTrials.gov
+                        or DRKS reported their results as either a journal publication or as summary
+                        results on the registry within 2 and 5 years after trial completion. Trials
+                        completed between 2009 and 2017 were considered.
+                        A fast dissemination of the trial results is crucial to make the evidence gained
+                        in those trials available. The World Health organization recommends publishing
+                        clinical trial results within one year after the end of a study.",
+                             
+                             HTML('ClinicalTrials.gov and DRKS.de were searched for studies with one of the UMCs
+                             as the responsible party/sponsor or with a principal investigator from one of the
+                             UMCs. A manual search for published results was done, searching the
+                        registry, PubMed and Google. When calculating the time to publication, we only
+                        considered trials where we could track the full timeframe since completion.
+                        The results were previously
+                        published as part of the <a href="https://s-quest.bihealth.org/intovalue/">IntoValue study</a>.
+                        Detailed methods can be found under
+                        <a href="https://doi.org/10.1101/467746">https://doi.org/10.1101/467746</a>.'),
+                             "Some detected publications might be missed in the manual search
+                        procedure as we only searched a limited number of scientific databases and did not
+                        contact the responsible parties. Furthermore, we did not include observational clinical
+                        studies in our sample. Additionally, we might overestimate the time to publication
+                        for some studies as we stopped the manual search after the first detected publication.")),
+
+    hr(),
+    h3("Open Access"),
+    bsCollapse(id = "methodsPanels_OpenAccess",
                
                methods_panel("Open Access",
                              
@@ -109,158 +206,54 @@ methods_page <- tabPanel(
                              database. The date at which a publication can be made openly accessible via self-archiving
                              depends on the publication date and the length of the embargo (if any). Therefore, the
                              number of potential green OA research articles will change over time. The Shareyourpaper
-                             permissions API was queried on 28/02/2021. The Unpaywall database was queried on 11/03/2021."),
-               
-               methods_panel("Open Data and Open Code",
-                             
-                             HTML('The Open Data and Open Code metrics measure how many publications
-                        share their raw research data or analysis code along with the publication.
-                        Openly shared data and code makes research more transparent,
-                        as research findings can be reproduced. Additionally, shared datasets
-                        can be reused and combined by other scientists to answer new research
-                        questions. The definition of Open Data used here is a low barrier definition.
-                        Only a part of the raw data underlying a study has to be freely available
-                        and no further quality criteria such as the FAIR criteria are checked. Note
-                        also that data sharing is not possible for all studies, for example if
-                        there is no dataset to be shared or if the data cannot be shared, e.g. due to privacy
-                        concerns for patient data. Data sharing under restrictions is currently not considered,
-                        but this is planned in the future.'),
-                             
-                             HTML('To identify publications which share research data or analysis code,
-                        we use the text-mining algorithm ODDPub
-                        (Code: <a href="https://github.com/quest-bih/oddpub">
-                        https://github.com/quest-bih/oddpub</a>,
-                        publication: <a href="https://datascience.codata.org/article/10.5334/dsj-2020-042/">
-                        https://datascience.codata.org/article/10.5334/dsj-2020-042/</a>)
-                        developed by QUEST. ODDPub searches the publication full-text
-                        for statements indicating sharing of raw data or analysis code.
-                        It does however not check the shared data itself.
-                        A text-mining approach is necessary, as a standardized
-                        way of sharing and reporting Open Data does not yet exist, and no database offers
-                        sufficiently comprehensive information on shared datasets or code.
-                        To assess data and code sharing for UMC publications, we first downloaded the
-                        full-texts of the publications that were accessible to us using the Unpaywall
-                        and Crossref APIs. We screened those full-texts with ODDPub and calculated the
-                        percentages of Open Data & Code relative to the publications in English and
-                                  available as full text.'),
-                             
-                             "Several limitations apply:
-                        Only full texts for Open Access publications or publications in journals to which
-                        we had a subscription could be retrieved (~78% of all detected publications).
-                        ODDPub only finds ~75% of all Open Data publications and finds false positive cases
-                        (no manual check of the results is done). ODDPub also does not verify that the
-                        indicated dataset is indeed available and whether the dataset fulfills our definition
-                        of Open Data. Open Data is not relevant for all publications, so we would not
-                        expect 100% of the publications to contain Open Data, not even in an ideal case.
-                        We considered all publications which had at least one author affiliated to one of the
-                        included UMCs. Authors with different project contributions and roles may have varing
-                        influence on the decision whether to make data or code available alongside a
-                        publication.")),
+                             permissions API was queried on 28/02/2021. The Unpaywall database was queried on 11/03/2021.")),
     
-    hr(),
-    h2("Clinical trials"),
-    bsCollapse(id = "methodsPanels_ClinicalTrials",
-               methods_panel("Summary results reporting",
-                             
-                             "This metric measures how many clinical trials registered in the
-                        EU Clinical Trials Register that are due to report their results have already
-                        done so. A trial is due to report its results 12 month after trial completion.
-                        Clinical trials are expensive and have often many contributing patients.
-                        A fast dissemination of the trial results is crucial to make the evidence gained
-                        in those trials available. The World Health organization recommends publishing
-                        clinical trial results within one year after the end of a study.",
-                             
-                             HTML('The data were retrieved for all UMCs included in this proof-of-principle
-                             dataset from the
-                        <a href="https://eu.trialstracker.net">EU Trials Tracker</a> by the EBM DataLab.'),
-                             
-                             "While the EU Clinical Trials Register is one of the most predominant
-                        European trial registries, it is not the only available registry. There are other
-                        registries such as ClinicalTrials.gov. or the German Clinical Trials Registry,
-                        which are not considered here. Additionally, the EU Trials Tracker does not
-                        measure for how long the trials have been due. Finally, we only considered the
-                             latest data available in the EU Trials Tracker. We plan to include historic
-                             data in the future."),
-               
-               methods_panel("Prospective registration",
-                             
-                             "This metric measures if the clinical trials are registered before the
-                        start date of the study, according to the information given on ClinicalTrials.gov.
-                        The idea of prospective registration of studies is to make the trial specifications,
-                        including primary and secondary outcomes, publicly available before study start.
-                        Prospective registration adds transparency, helps protect against outcome switching.",
-                             
-                             "We used the same methods as for the timely reporting metric to identify trials
-                             from UMCs. To assess if a study has been prospectively registered, we compare
-                        the date the study was first submitted to the registry with the
-                        start date given in the registry. As some of the earlier dates in the database
-                        only stated the month but not the exact day and to account for other possible delays
-                        we chose a conservative estimate of prospective registration and allow for a delay
-                        between start and registration date of up to 60 days.",
-                             
-                             "Like in the case of the summary results metric, we only focused on the
-                        ClinicalTrials.gov while there are other available registries as well.
-                        Also, we rely on the information on ClinicalTrials.gov being accurate."),
-               
-               methods_panel("Timely publication of results",
-                             
-                             "This metric measures how many clinical trials registered on ClinicalTrials.gov
-                        reported their results either as a journal publication or as summary
-                        results on the trials registry within 2 years after completion. Trials
-                        completed between 2009 and 2017 were considered.
-                        A fast dissemination of the trial results is crucial to make the evidence gained
-                        in those trials available. The World Health organization recommends publishing
-                        clinical trial results within one year after the end of a study.",
-                             
-                             HTML('ClinicalTrials.gov and DRKS.de were searched for studies with one of the UMCs
-                             as the responsible party/sponsor or with a principal investigator from one of the
-                             UMCs. A manual search for published results was done, searching the
-                        registry, PubMed and Google. When calculating the time to publication, we only
-                        considered trials where we could track the full timeframe since completion.
-                        The results were previously
-                        published as part of the <a href="https://s-quest.bihealth.org/intovalue/">IntoValue study</a>.
-                        Detailed methods can be found under
-                        <a href="https://doi.org/10.1101/467746">https://doi.org/10.1101/467746</a>.'),
-                             "Some detected publications might be missed in the manual search
-                        procedure as we only searched a limited number of scientific databases and did not
-                        contact the responsible parties. Furthermore, we did not include observational clinical
-                        studies in our sample. Additionally, we might overestimate the time to publication
-                        for some studies as we stopped the manual search after the first detected publication."),
-               
-               methods_panel("Reporting of Trial Registration Number (TRN)",
-                             
-                             HTML("Reporting of clinical trial registration numbers in related publications
-                             facilitates transparent linkage between registration and publication and enhances
-                             the value of the individual parts towards more responsible biomedical research
-                             and evidence-based medicine. The <a 
-                             href=https://www.sciencedirect.com/science/article/pii/S0140673607618352?via%3Dihub>
-                             Consolidated Standards of Reporting Trials (CONSORT)</a>
-                             as well as the <a href=http://www.icmje.org/recommendations/>ICMJE Recommendations
-                             for the Conduct, Reporting, Editing, and Publication of Scholarly Work in Medical
-                             Journals</a> call for reporting <i>&#39trial registration number and name of the
-                             trial register&#39</i> in both the full-text and abstract."),
-                             
-                             HTML('We developed an <a href="https://github.com/maia-sh/ctregistries">open source R
-                                  package</a> for the detection and classification of clinical trial registration
-                                  numbers. Our regular-expression-based algorithm searches text strings for
-                                  matches to TRN patterns for all PubMed-indexed and ICTRP-network registries.
-                                  In a first step, we filtered the publication dataset for PubMed-classified
-                                  human clinical trials. Then, we used the aforementioned package to detect
-                                  and classify trial registration numbers in the PubMed secondary identifier
-                                  metadata and abstract.'),
-                             
-                             HTML("We identified human clinical trials based on the following search term in PubMed:
-                             <code>&#39clinical trial&#39[pt] NOT (animals [mh] NOT humans [mh])</code>. However,
-                             we have not tested (1) the sensitivity of this PubMed search term (i.e., what
-                             proportion of true clinical trial publications are detected?); (2) the precision
-                             of this search term (i.e, what proportion of detected publications are not true
-                             clinical trials publications?). Furthermore, our algorithm does not
-                                  distinguish true TRNs that do not resolve to a registration. Finally, the
-                                  algorithm does not determine whether the TRN is reported as a registration
-                                  for the publication&#39s study (i.e., clinical trial result) or is otherwise
-                                  mentioned (i.e., in a review, reference to other clinical trials, etc.)"))),
-               
-    hr(),
+    # methods_panel("Open Data and Open Code",
+    #               
+    #               HTML('The Open Data and Open Code metrics measure how many publications
+    #          share their raw research data or analysis code along with the publication.
+    #          Openly shared data and code makes research more transparent,
+    #          as research findings can be reproduced. Additionally, shared datasets
+    #          can be reused and combined by other scientists to answer new research
+    #          questions. The definition of Open Data used here is a low barrier definition.
+    #          Only a part of the raw data underlying a study has to be freely available
+    #          and no further quality criteria such as the FAIR criteria are checked. Note
+    #          also that data sharing is not possible for all studies, for example if
+    #          there is no dataset to be shared or if the data cannot be shared, e.g. due to privacy
+    #          concerns for patient data. Data sharing under restrictions is currently not considered,
+    #          but this is planned in the future.'),
+    #               
+    #               HTML('To identify publications which share research data or analysis code,
+    #          we use the text-mining algorithm ODDPub
+    #          (Code: <a href="https://github.com/quest-bih/oddpub">
+    #          https://github.com/quest-bih/oddpub</a>,
+    #          publication: <a href="https://datascience.codata.org/article/10.5334/dsj-2020-042/">
+    #          https://datascience.codata.org/article/10.5334/dsj-2020-042/</a>)
+    #          developed by QUEST. ODDPub searches the publication full-text
+    #          for statements indicating sharing of raw data or analysis code.
+    #          It does however not check the shared data itself.
+    #          A text-mining approach is necessary, as a standardized
+    #          way of sharing and reporting Open Data does not yet exist, and no database offers
+    #          sufficiently comprehensive information on shared datasets or code.
+    #          To assess data and code sharing for UMC publications, we first downloaded the
+    #          full-texts of the publications that were accessible to us using the Unpaywall
+    #          and Crossref APIs. We screened those full-texts with ODDPub and calculated the
+    #          percentages of Open Data & Code relative to the publications in English and
+    #                    available as full text.'),
+    #               
+    #               "Several limitations apply:
+    #          Only full texts for Open Access publications or publications in journals to which
+    #          we had a subscription could be retrieved (~78% of all detected publications).
+    #          ODDPub only finds ~75% of all Open Data publications and finds false positive cases
+    #          (no manual check of the results is done). ODDPub also does not verify that the
+    #          indicated dataset is indeed available and whether the dataset fulfills our definition
+    #          of Open Data. Open Data is not relevant for all publications, so we would not
+    #          expect 100% of the publications to contain Open Data, not even in an ideal case.
+    #          We considered all publications which had at least one author affiliated to one of the
+    #          included UMCs. Authors with different project contributions and roles may have varing
+    #          influence on the decision whether to make data or code available alongside a
+    #          publication.")),
+    
     ## h2("Robustness"),
     ## bsCollapse(id = "methodsPanels_Robustness",
     ##            methods_panel("Robustness of animal studies",

--- a/shiny_app/start_page_plots.R
+++ b/shiny_app/start_page_plots.R
@@ -1406,7 +1406,7 @@ plot_clinicaltrials_prereg <- function (dataset, umc, color_palette) {
                 ) %>%
                     layout(
                         xaxis = list(
-                            title = '<b>Completion year</b>',
+                            title = '<b>Year</b>',
                             dtick = 1
                         ),
                         yaxis = list(

--- a/shiny_app/start_page_plots.R
+++ b/shiny_app/start_page_plots.R
@@ -1273,7 +1273,7 @@ plot_clinicaltrials_sumres <- function (dataset, umc, color_palette) {
                     title = '<b>Date</b>'
                 ),
                 yaxis = list(
-                    title = '<b>Summary results reported (%)</b>',
+                    title = '<b>Reported within 1 year (%)</b>',
                     range = c(0, 100)
                 ),
                 paper_bgcolor = color_palette[9],
@@ -1312,7 +1312,7 @@ plot_clinicaltrials_sumres <- function (dataset, umc, color_palette) {
                     title = '<b>Date</b>'
                 ),
                 yaxis = list(
-                    title = '<b>Summary results reported (%)</b>',
+                    title = '<b>Reported within 1 year (%)</b>',
                     range = c(0, 100)
                 ),
                 paper_bgcolor = color_palette[9],


### PR DESCRIPTION
- Adapted methods for the dashboard on clinical research (including list of tools)
- [ ] TODO: more work needed on the description of how trials and publications were identified.
- Made the underlying registry(-ies) clearer for each metric, where applicable
- Removed mention of 2018 for Open Access plot
- Changed "Open Science" section to "Open Access"
- Adapted general overview text on the first page
- Adapted the contributions page