### PR TITLE
Updated UMC names for historic EUTT data

### DIFF
--- a/prep/eutt-history.R
+++ b/prep/eutt-history.R
@@ -26,13 +26,12 @@ commits$date <- commits$ymd %>%
     as.Date(format="%Y %b %d")
 commits <- commits %>%
     select(hash, date) %>%
-    filter(date > Sys.Date()-365*2)
+    filter(date > Sys.Date()-365*2) #adapt as necessary
 
 output_filename <- paste0(Sys.Date(), "-eutt-history.csv")
 
+# Select sponsors you want to get the data from in EUTT
 sponsors_of_interest <- read_csv("eutt-sponsors-of-interest.csv")
-## Could not match the following (or don't know what they mean):
-## Frankfurt
 
 if (!file.exists(output_filename)) {
     tribble(

--- a/prep/eutt-sponsors-of-interest.csv
+++ b/prep/eutt-sponsors-of-interest.csv
@@ -1,35 +1,40 @@
 sponsor_name,city
 RWTH Aachen University,Aachen
+Klinikum Augsburg,UK Augsburg
 Charité-Universitätsmedizin Berlin,Berlin
 Ruhr University Bochum,Bochum
 University of Bonn,Bonn
 Dresden University of Technology,Dresden
-University Duisburg-Essen,Duisberg
+University Duisburg-Essen,Duisberg-Essen
 Heinrich Heine University Düsseldorf,Düsseldorf
 University Erlangen-Nuremberg,Erlangen
+Goethe University,Frankfurt
 University of Freiburg,Freiburg
-University of Giessen,Giessen
+University of Giessen,Gießen
+University Hospital Giessen and Marburg,UKGM
 University of Göttingen,Göttingen
 Medical University Greifswald,Greifswald
-Martin Luther University Halle-Wittenberg,Halle
+Martin Luther University Halle-Wittenberg,Halle-Wittenberg
 University of Hamburg,Hamburg
 Hannover Medical School,Hannover
 Heidelberg University,Heidelberg
+Heidelberg University Hospital,UK Heidelberg
 Saarland University,Homburg
 Friedrich Schiller University Jena,Jena
 University of Kiel,Kiel
+Schleswig-Holstein University Hospital,UKSH
 University of Cologne,Köln
 Leipzig University,Leipzig
 Otto von Guericke University Magdeburg,Magdeburg
 Johannes Gutenberg University of Mainz,Mainz
 Philipps-University Marburg,Marburg
+University of Munich (Ludwig-Maximilians),LMU München
+Technical University of Munich,TU München
 University of Münster,Münster
 University of Regensburg,Regensburg
 Universität Rostock,Rostock
-Schleswig-Holstein University Hospital,Schleswig-Holstein
 Eberhard Karls University Tübingen,Tübingen
+University Hospital Tübingen,UK Tübingen
 University of Ulm,Ulm
-University of Witten/Herdecke,Witten-Herdecke
+University of Witten/Herdecke,Witten/Herdecke
 Julius Maximilian University of Würzburg,Würzburg
-University of Munich (Ludwig-Maximilians),LMU
-Technical University of Munich,TU


### PR DESCRIPTION
- Selected relevant names in EUTT for medical faculties in Germany (search on 20/04/2021). This may need to be updated again in the future.
- Minor changes to the comments in the script for clarity.